### PR TITLE
fix: add required route53 records for custom mail from domain

### DIFF
--- a/route53.tf
+++ b/route53.tf
@@ -38,3 +38,20 @@ resource "aws_route53_record" "ses_verification" {
   ttl     = "600"
   records = [aws_ses_domain_identity.domain_id.verification_token]
 }
+
+resource "aws_route53_record" "ses_domain_mail_from_mx" {
+  zone_id = var.route53_zone_id
+  name    = aws_ses_domain_mail_from.mail_from.mail_from_domain
+  type    = "MX"
+  ttl     = "600"
+  records = var.mail_from_mx_records
+}
+
+resource "aws_route53_record" "ses_domain_mail_from_spf" {
+  zone_id = var.route53_zone_id
+  name    = aws_ses_domain_mail_from.mail_from.mail_from_domain
+  type    = "TXT"
+  ttl     = "600"
+  records = var.spf_records
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -25,3 +25,9 @@ variable "spf_records" {
   default     = ["v=spf1 include:amazonses.com -all"]
   description = "Route53 MX record which defines valid mail servers. Defaults to `v=spf1 include:amazonses.com -all`"
 }
+
+variable "mail_from_mx_records" {
+  type        = list(string)
+  default     = ["10 feedback-smtp.us-east-1.amazonses.com"]
+  description = "Route53 MX record which validates custom mail from subdomain. Defaults to `10 feedback-smtp.us-east-1.amazonses.com`."
+}


### PR DESCRIPTION
Currently the module creates a custom mail from domain resource, however it does not create the required route53 mx and spf records to validate that mail from resource.  This pull request remediates that issue.